### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -11,5 +11,5 @@
 services:
     ucsf_ldap_orm.entity_manager:
       class: Ucsf\LdapOrmBundle\Ldap\LdapEntityManager
-      arguments: [ "@logger", "@annotation_reader", %ucsfldaporm_test% ]
+      arguments: [ "@logger", "@annotation_reader", "%ucsfldaporm_test%" ]
 


### PR DESCRIPTION
Not quoting the scalar "%ucsfldaporm_test% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0.